### PR TITLE
Deploy to NPM using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+node_js:
+ - 6
+
+script:
+ - yarn run lint
+ - yarn run test
+ - yarn run build:library
+
+deploy:
+  skip_cleanup: true
+  provider: npm
+  email: systems@azavea.com
+  api_key:
+    secure: RvGHhs27KZMXQVYEksmawgzTJiBYiEUDXJX1Oed57BbGYPB+M1cdUIdm2Gh/Qw0CY8zx5pVdnsVCcGCBLV5GlZGhUPQBQLo89t7vbfTu27zGvN72BPB/UyYB5GzgDdjy35AwPDx1yvdPLTaoXMTKIsHy6ME1M6f2O4XDEfh5wHG4hffVeq7hklKER5+xLCo9aOWfb23qNTjfDPRWRXbfdU+PuLKJ6JzIHnh9zLTCXmCrv++vVDfVZZPdMQvErFlaXfDKwTBgCbxbYQz/i4gZz00OZddp9CsmBLeHgoSFSscoHg0qzfVKmccDQ3BaaMew2yxxfVKXA7XI60GJO9i5wsuKHW6mcXLaTCCYIvEowDJAUBRbawLAIEsEy/IFH8+e1EPUIcJpNgqSQlvpdsuMyPMx60WYMBbLX1Rn46wAIohtXp3Foqg8ArkFNIrsCFLuaINP4Bh5Puqqi5EzyLyWg2+gJ/5Z8V58vJ5z+fRWIbBH1APby3o9vO8Dnv+lw7EJJrPVnWkexAEVUGq5TXLYxV9xV33OG8kjeu51EaEWsNLFncVdINmR20RKZv8yWTGaiY0PuqdVINpnwhhrqSx7p/jg8xZ21V6zrrpo2L5j/v6dA9rmwLPWzc7EJLBEymChPda4o1jnJZMBctBJvETarTy1Gqh4yG3EZwSsR/sK6PE=
+  on:
+    tags: true
+
+repo: azavea/climate-change-components

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 
+## Publishing new versions
+
+Publishing a new version to NPM is handled by Travis CI when tags are pushed to Github.
+
+Make sure to update the version number in `package.json` before creating a new tag.
+
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "climate-change-components",
   "version": "0.0.0",
-  "license": "MIT",
+  "license": "Apache-2.0",
+  "repository" : {
+      "type" : "git",
+      "url" : "https://github.com/azavea/climate-change-components.git"
+  },
   "main": "./lib-dist/public_api.js",
   "types": "./lib-dist/public_api.d.js",
   "scripts": {
@@ -10,7 +14,6 @@
     "lint": "ng lint --type-check",
     "e2e": "ng e2e"
   },
-  "private": true,
   "dependencies": {
     "@angular/animations": "^4.3.6",
     "@angular/common": "^4.3.6",


### PR DESCRIPTION
## Overview

Adds a `.travis.yml` to test pull requests and deploy to NPM when tags are pushed.
The `.travis.yml` is based heavily on https://github.com/azavea/tilejson-validator

After this is merged I'll update the version in `package.json` and push the first release.

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

Addresses #4 

