### PR TITLE
Update precipitation threshold units

### DIFF
--- a/src/lib/modules/shared/extra-params.constants.ts
+++ b/src/lib/modules/shared/extra-params.constants.ts
@@ -37,9 +37,9 @@ export const TemperatureUnits: any[] = [
  ];
 
 export const PrecipitationUnits: any[] = [
-    {'key': 'mm', 'label': 'millimeters'},
-    {'key': 'in', 'label': 'inches'},
-    {'key': 'kg/m^2', 'label': 'kg/m^2'}
+    {'key': 'mm/day', 'label': 'millimeters per day'},
+     {'key': 'in/day', 'label': 'inches per day'},
+     {'key': 'kg/m^2/s', 'label': 'kg/m^2/s'}
 ];
 
 export function isBasetempIndicator(indicatorName: string): boolean {
@@ -52,11 +52,6 @@ export function isHistoricIndicator(indicatorName: string): boolean {
 
 export function isThresholdIndicator(indicatorName: string): boolean {
     return thresholdIndicatorNames.indexOf(indicatorName) !== -1;
-}
-
-// TODO: use or remove this function
-export function hasExtraParams(indicatorName: string): boolean {
-    return extraParamsIndicatorNames.indexOf(indicatorName) !== -1;
 }
 
 export function isPercentileIndicator(indicatorName: string): boolean {

--- a/src/lib/modules/shared/index.ts
+++ b/src/lib/modules/shared/index.ts
@@ -2,7 +2,6 @@
 export {
   PrecipitationUnits,
   TemperatureUnits,
-  hasExtraParams,
   isBasetempIndicator,
   isHistoricIndicator,
   isPercentileIndicator,


### PR DESCRIPTION
## Overview

Re-apply changes lost from azavea/climate-change-lab#280: update precipitation units to match API. The default unit was correct, but not the drop-down options.


### Demo

![precip_threshold](https://user-images.githubusercontent.com/960264/32451759-aece81ec-c2e5-11e7-9cdb-558986c07b72.png)


### Notes

Will require a version bump and changelog update in this repository and to the installed version of this package in the lab project; could be done with an update to #9, if this goes in first.


## Testing Instructions

 * `yarn install`
 * `yarn run build:library`
 * `npm pack`
 * In the lab project: `npm install ../climate-change-components/climate-change-components-0.2.0.tgz`
 * In the lab: `yarn run serve`
 * http://localhost:4200
 * load precipitation threshold chart
 * chart should load with any of the three options for precipitation units

## Checklist
- [x] `yarn run build:library` clean?
- [x] `yarn run lint` clean?

Fixes #6.

