### PR TITLE
Create and use HISTORIC_RANGE_DEFAULT in extra params components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- PercentileHistoricComponent and HistoricComponent now automatically choose a sensible dropdown
+  default for the historic baseline parameter
 
 ## [0.2.1] - 2017-11-07
 ### Added

--- a/src/lib/modules/api/index.ts
+++ b/src/lib/modules/api/index.ts
@@ -9,7 +9,7 @@ export { ClimateModel } from './models/climate-model.model';
 export { DataPoint } from './models/data-point.model';
 export { Dataset } from './models/dataset.model';
 export { HistoricIndicatorQueryParams } from './models/historic-indicator-query-params.model';
-export { HistoricRange } from './models/historic-range.model';
+export { HistoricRange, HISTORIC_RANGE_DEFAULT } from './models/historic-range.model';
 export { IndicatorParameter } from './models/indicator-parameter.model';
 export { IndicatorQueryParams } from './models/indicator-query-params.model';
 export { IndicatorRequestOpts } from './models/indicator-request-opts.model';

--- a/src/lib/modules/api/index.ts
+++ b/src/lib/modules/api/index.ts
@@ -9,7 +9,7 @@ export { ClimateModel } from './models/climate-model.model';
 export { DataPoint } from './models/data-point.model';
 export { Dataset } from './models/dataset.model';
 export { HistoricIndicatorQueryParams } from './models/historic-indicator-query-params.model';
-export { HistoricRange, HISTORIC_RANGE_DEFAULT } from './models/historic-range.model';
+export { HistoricRange } from './models/historic-range.model';
 export { IndicatorParameter } from './models/indicator-parameter.model';
 export { IndicatorQueryParams } from './models/indicator-query-params.model';
 export { IndicatorRequestOpts } from './models/indicator-request-opts.model';

--- a/src/lib/modules/api/models/historic-range.model.ts
+++ b/src/lib/modules/api/models/historic-range.model.ts
@@ -1,3 +1,5 @@
+export const HISTORIC_RANGE_DEFAULT = '1971';
+
 export interface HistoricRange {
   start_year: string;
   end_year: string;

--- a/src/lib/modules/api/models/historic-range.model.ts
+++ b/src/lib/modules/api/models/historic-range.model.ts
@@ -1,4 +1,3 @@
-export const HISTORIC_RANGE_DEFAULT = '1971';
 
 export interface HistoricRange {
   start_year: string;

--- a/src/lib/modules/charts/components/extra-params/historic.component.ts
+++ b/src/lib/modules/charts/components/extra-params/historic.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
-import { HistoricRange, HISTORIC_RANGE_DEFAULT } from '../../../api/models/historic-range.model';
+import { HistoricRange } from '../../../api/models/historic-range.model';
 import { HistoricIndicatorQueryParams } from '../../../api/models/historic-indicator-query-params.model';
 import { HistoricRangeService } from '../../../api/services/historic-range.service';
 import { Indicator } from '../../../api/models/indicator.model';
@@ -21,7 +21,7 @@ export class HistoricComponent implements AfterViewInit, OnInit {
     @Output() historicParamSelected = new EventEmitter<HistoricIndicatorQueryParams>();
 
     historicForm: FormGroup;
-    public historicRangeOptions: string[] = [];
+    public historicRangeOptions: number[] = [];
 
     constructor(private formBuilder: FormBuilder,
                 private historicRangeService: HistoricRangeService) {}
@@ -42,7 +42,7 @@ export class HistoricComponent implements AfterViewInit, OnInit {
 
     createForm() {
         this.historicForm = this.formBuilder.group({
-            historicCtl: [this.extraParams.historic_range || HISTORIC_RANGE_DEFAULT],
+            historicCtl: [this.extraParams.historic_range],
         });
 
         this.historicForm.valueChanges.debounceTime(700).subscribe(form => {
@@ -54,7 +54,11 @@ export class HistoricComponent implements AfterViewInit, OnInit {
 
     getHistoricRanges() {
         this.historicRangeService.list().subscribe(data => {
-            this.historicRangeOptions = data.map(h => h.start_year);
+            this.historicRangeOptions = data.map(h => parseInt(h.start_year, 10));
+            if (!this.extraParams.historic_range) {
+              const latestHistoricRange = Math.max(...this.historicRangeOptions);
+              this.historicForm.setValue({historicCtl: latestHistoricRange});
+            }
         });
     }
 }

--- a/src/lib/modules/charts/components/extra-params/historic.component.ts
+++ b/src/lib/modules/charts/components/extra-params/historic.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
-import { HistoricRange } from '../../../api/models/historic-range.model';
+import { HistoricRange, HISTORIC_RANGE_DEFAULT } from '../../../api/models/historic-range.model';
 import { HistoricIndicatorQueryParams } from '../../../api/models/historic-indicator-query-params.model';
 import { HistoricRangeService } from '../../../api/services/historic-range.service';
 import { Indicator } from '../../../api/models/indicator.model';
@@ -23,9 +23,6 @@ export class HistoricComponent implements AfterViewInit, OnInit {
     historicForm: FormGroup;
     public historicRangeOptions: string[] = [];
 
-    // default form values
-    private defaultHistoric = null;
-
     constructor(private formBuilder: FormBuilder,
                 private historicRangeService: HistoricRangeService) {}
 
@@ -45,7 +42,7 @@ export class HistoricComponent implements AfterViewInit, OnInit {
 
     createForm() {
         this.historicForm = this.formBuilder.group({
-            historicCtl: [this.extraParams.historic_range || this.defaultHistoric],
+            historicCtl: [this.extraParams.historic_range || HISTORIC_RANGE_DEFAULT],
         });
 
         this.historicForm.valueChanges.debounceTime(700).subscribe(form => {
@@ -58,8 +55,6 @@ export class HistoricComponent implements AfterViewInit, OnInit {
     getHistoricRanges() {
         this.historicRangeService.list().subscribe(data => {
             this.historicRangeOptions = data.map(h => h.start_year);
-            // add empty option, as this is not a required parameter
-            this.historicRangeOptions.unshift('');
         });
     }
 }

--- a/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
+++ b/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
-import { HistoricRange, HISTORIC_RANGE_DEFAULT } from '../../../api/models/historic-range.model';
+import { HistoricRange } from '../../../api/models/historic-range.model';
 import { PercentileHistoricIndicatorQueryParams } from '../../../api/models/percentile-historic-indicator-query-params.model';
 import { HistoricRangeService } from '../../../api/services/historic-range.service';
 import { Indicator } from '../../../api/models/indicator.model';
@@ -21,7 +21,7 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
     @Output() percentileHistoricParamSelected = new EventEmitter<PercentileHistoricIndicatorQueryParams>();
 
     percentileHistoricForm: FormGroup;
-    public historicRangeOptions: string[] = [];
+    public historicRangeOptions: number[] = [];
 
     // default form values
     private defaultPercentile = 50;
@@ -46,7 +46,7 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
 
     createForm() {
         this.percentileHistoricForm = this.formBuilder.group({
-            historicCtl: [this.extraParams.historic_range || HISTORIC_RANGE_DEFAULT],
+            historicCtl: [this.extraParams.historic_range],
             percentileCtl: [this.extraParams.percentile || this.defaultPercentile, Validators.required]
         });
 
@@ -64,7 +64,14 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
 
     getHistoricRanges() {
         this.historicRangeService.list().subscribe(data => {
-            this.historicRangeOptions = data.map(h => h.start_year);
+            this.historicRangeOptions = data.map(h => parseInt(h.start_year, 10));
+            if (!this.extraParams.historic_range) {
+              const latestHistoricRange = Math.max(...this.historicRangeOptions);
+              this.percentileHistoricForm.setValue({
+                historicCtl: latestHistoricRange,
+                percentileCtl: this.percentileHistoricForm.controls.percentileCtl.value
+              });
+            }
         });
     }
 }

--- a/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
+++ b/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
-import { HistoricRange } from '../../../api/models/historic-range.model';
+import { HistoricRange, HISTORIC_RANGE_DEFAULT } from '../../../api/models/historic-range.model';
 import { PercentileHistoricIndicatorQueryParams } from '../../../api/models/percentile-historic-indicator-query-params.model';
 import { HistoricRangeService } from '../../../api/services/historic-range.service';
 import { Indicator } from '../../../api/models/indicator.model';
@@ -24,7 +24,6 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
     public historicRangeOptions: string[] = [];
 
     // default form values
-    private defaultHistoric = null;
     private defaultPercentile = 50;
 
     constructor(private formBuilder: FormBuilder,
@@ -47,7 +46,7 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
 
     createForm() {
         this.percentileHistoricForm = this.formBuilder.group({
-            historicCtl: [this.extraParams.historic_range || this.defaultHistoric],
+            historicCtl: [this.extraParams.historic_range || HISTORIC_RANGE_DEFAULT],
             percentileCtl: [this.extraParams.percentile || this.defaultPercentile, Validators.required]
         });
 
@@ -66,8 +65,6 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
     getHistoricRanges() {
         this.historicRangeService.list().subscribe(data => {
             this.historicRangeOptions = data.map(h => h.start_year);
-            // add empty option, as this is not a required parameter
-            this.historicRangeOptions.unshift('');
         });
     }
 }


### PR DESCRIPTION
Value of HISTORIC_RANGE_DEFAULT matches default historic_range
param value of the Climate API

## Overview

Updates the historic range param controls to just automatically set themselves to the same value that the Climate API defaults to (1971) without presenting a "blank" option, since the API selects a default anyways if no param value is provided. This reduces confusion as to what the dropdown options mean in the Lab.


### Demo

Both screenshots taken after selecting the indicator shown. No further actions taken to select extra params values:

![screen shot 2017-11-20 at 15 48 23](https://user-images.githubusercontent.com/1818302/33040887-7f2fb53e-ce0a-11e7-931f-259ca8a83ea7.png)
![screen shot 2017-11-20 at 15 48 14](https://user-images.githubusercontent.com/1818302/33040888-7f3e8820-ce0a-11e7-9265-8c3763a9d537.png)


## Testing Instructions

Once this branch is checked out, run:
```
yarn run build:library && npm pack
```
Now checkout `develop` on climate-change-lab, ensure node_modules is up to date with `yarn install` and then manually install the climate-change-components package with:
```
npm install ../climate-change-components/climate-change-components-0.2.1.tgz
```

You should now be able to select any of the indicators that use the historic_range param and get a default value selected for you when the indicator loads.

I had some trouble with my `apiHost` in lab set to `https://app.staging.climate.azavea.com`. Starting my local Climate API box on at least the current develop and setting `apiHost = http://localhost:8080` worked as a replacement.

Closes #12 