### PR TITLE
Limit HistoricPercentile param to valid options

### DIFF
--- a/src/lib/modules/api/index.ts
+++ b/src/lib/modules/api/index.ts
@@ -15,6 +15,7 @@ export { IndicatorQueryParams } from './models/indicator-query-params.model';
 export { IndicatorRequestOpts } from './models/indicator-request-opts.model';
 export { Indicator } from './models/indicator.model';
 export { MultiDataPoint } from './models/multi-data-point.model';
+export { HistoricPercentileParam, HistoricPercentileParamOptions } from './models/historic-percentile-param.enum';
 export { PercentileIndicatorQueryParams } from './models/percentile-indicator-query-params.model';
 export { PercentileHistoricIndicatorQueryParams } from './models/percentile-historic-indicator-query-params.model';
 export { Scenario } from './models/scenario.model';

--- a/src/lib/modules/api/models/historic-percentile-param.enum.ts
+++ b/src/lib/modules/api/models/historic-percentile-param.enum.ts
@@ -1,0 +1,13 @@
+
+export enum HistoricPercentileParam {
+  One = 1,
+  Five = 5,
+  NinetyFive = 95,
+  NinetyNine = 99
+}
+
+const keys = Object.keys(HistoricPercentileParam).filter(k => {
+  return typeof HistoricPercentileParam[k as any] === 'number';
+});
+
+export const HistoricPercentileParamOptions = keys.map(k => HistoricPercentileParam[k as any]);

--- a/src/lib/modules/api/models/percentile-historic-indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/percentile-historic-indicator-query-params.model.ts
@@ -1,6 +1,7 @@
 import { IndicatorQueryParams } from './indicator-query-params.model';
+import { HistoricPercentileParam } from './historic-percentile-param.enum';
 
 export interface PercentileHistoricIndicatorQueryParams extends IndicatorQueryParams {
   historic_range: Number;
-  percentile: Number;
+  percentile: HistoricPercentileParam;
 }

--- a/src/lib/modules/api/models/percentile-indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/percentile-indicator-query-params.model.ts
@@ -1,5 +1,5 @@
 import { IndicatorQueryParams } from './indicator-query-params.model';
 
 export interface PercentileIndicatorQueryParams extends IndicatorQueryParams {
-  percentile: Number;
+  percentile: number;
 }

--- a/src/lib/modules/charts/components/extra-params/percentile-historic.component.html
+++ b/src/lib/modules/charts/components/extra-params/percentile-historic.component.html
@@ -1,13 +1,15 @@
 <div class="chart-options-group historic percentile">
     <form [formGroup]="percentileHistoricForm" novalidate>
         <div class="chart-options-body form-group">
-            <span class="optional-parameters-label">Show {{indicator.label | lowercase}} at percentile
-                <input type="number"
-                       min="1"
-                       max="100"
-                       step="1"
-                       formControlName="percentileCtl">
-            with historic base range year</span>
+            <span class="optional-parameters-label">Show {{indicator.label | lowercase}} at percentile</span>
+            <div class="chart-options-group">
+                <select class="form-control chart-options-group" formControlName="percentileCtl">
+                    <option *ngFor="let percentile of percentileOptions"
+                        [value]="percentile">{{percentile}}
+                    </option>
+                </select>
+            </div>
+            <span class="optional-parameters-label">with historic base range year</span>
             <div class="chart-options-group">
                 <select class="form-control chart-options-group" formControlName="historicCtl">
                     <option *ngFor="let startYear of historicRangeOptions"

--- a/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
+++ b/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
@@ -47,7 +47,9 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
     createForm() {
         this.percentileHistoricForm = this.formBuilder.group({
             historicCtl: [this.extraParams.historic_range],
-            percentileCtl: [this.extraParams.percentile || HistoricPercentileParam.NinetyFive]
+            percentileCtl: [
+              this.extraParams.percentile || this.defaultPercentileForIndicator(this.indicator)
+            ]
         });
 
         this.percentileHistoricForm.valueChanges.debounceTime(700).subscribe(form => {
@@ -73,5 +75,13 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
               });
             }
         });
+    }
+
+    private defaultPercentileForIndicator(indicator: Indicator) {
+      if (indicator.name === 'extreme_cold_events') {
+        return HistoricPercentileParam.One;
+      } else {
+        return HistoricPercentileParam.NinetyNine;
+      }
     }
 }

--- a/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
+++ b/src/lib/modules/charts/components/extra-params/percentile-historic.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 import { HistoricRange } from '../../../api/models/historic-range.model';
 import { PercentileHistoricIndicatorQueryParams } from '../../../api/models/percentile-historic-indicator-query-params.model';
+import { HistoricPercentileParam, HistoricPercentileParamOptions } from '../../../api/models/historic-percentile-param.enum';
 import { HistoricRangeService } from '../../../api/services/historic-range.service';
 import { Indicator } from '../../../api/models/indicator.model';
 
@@ -21,10 +22,9 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
     @Output() percentileHistoricParamSelected = new EventEmitter<PercentileHistoricIndicatorQueryParams>();
 
     percentileHistoricForm: FormGroup;
-    public historicRangeOptions: number[] = [];
 
-    // default form values
-    private defaultPercentile = 50;
+    public historicRangeOptions: number[] = [];
+    public percentileOptions = HistoricPercentileParamOptions;
 
     constructor(private formBuilder: FormBuilder,
                 private historicRangeService: HistoricRangeService) {}
@@ -47,7 +47,7 @@ export class PercentileHistoricComponent implements AfterViewInit, OnInit {
     createForm() {
         this.percentileHistoricForm = this.formBuilder.group({
             historicCtl: [this.extraParams.historic_range],
-            percentileCtl: [this.extraParams.percentile || this.defaultPercentile, Validators.required]
+            percentileCtl: [this.extraParams.percentile || HistoricPercentileParam.NinetyFive]
         });
 
         this.percentileHistoricForm.valueChanges.debounceTime(700).subscribe(form => {

--- a/src/lib/modules/shared/extra-params.constants.ts
+++ b/src/lib/modules/shared/extra-params.constants.ts
@@ -15,6 +15,7 @@ const historicIndicatorNames = [
     'heat_wave_duration_index',
     'heat_wave_incidents',
     'extreme_heat_events',
+    'extreme_cold_events',
     'extreme_precipitation_events'
 ];
 
@@ -23,6 +24,7 @@ const percentileIndicatorNames = [
     'percentile_low_temperature',
     'percentile_precipitation',
     'extreme_heat_events',
+    'extreme_cold_events',
     'extreme_precipitation_events'
 ];
 


### PR DESCRIPTION
## Overview

Update component to use dropdown since we only calculate historic percentiles for a few select values. 


### Demo

![screen shot 2017-11-20 at 16 38 01](https://user-images.githubusercontent.com/1818302/33042833-361d0354-ce11-11e7-8405-94441cbb1e3c.png)


## Testing Instructions

See #15 for instructions on how to prepare your lab VM to test.

Then, load up any of the percentile+historic indicators, such as "Extreme Precip Events" and ensure that 1. a default of 95 is loaded and 2. that you are limited to the values specified in #14 

Closes #14 

