### PR TITLE
Add in memory cache and use for API list calls

### DIFF
--- a/src/lib/modules/api/api.module.ts
+++ b/src/lib/modules/api/api.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 import { API_HOST, API_HTTP, ApiConfig } from './config';
 
+import { APICacheService } from './services/api-cache.service';
 import { ChartService } from './services/chart.service';
 import { DatasetService } from './services/dataset.service';
 import { ClimateModelService } from './services/climate-model.service';
@@ -21,6 +22,7 @@ export class ApiModule {
     return {
       ngModule: ApiModule,
       providers: [
+        APICacheService,
         ChartService,
         DatasetService,
         ClimateModelService,

--- a/src/lib/modules/api/services/api-cache.service.ts
+++ b/src/lib/modules/api/services/api-cache.service.ts
@@ -1,0 +1,81 @@
+/**
+ * Derived from cache.service.ts in
+ *  https://github.com/ashwin-sureshkumar/angular-cache-service-blog
+ * Implements a secondary in-flight cache so that multiple requests for the same object
+ *  will share a single subject. Avoids multiple calls for a result while the first is
+ *  still pending.
+ */
+import { Injectable } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs/Rx';
+
+interface CacheValue {
+    expiry: number;
+    value: any;
+}
+
+@Injectable()
+export class APICacheService {
+
+  public readonly DEFAULT_MAX_AGE_S = 60 * 60 * 24;
+
+  private cache: Map<string, CacheValue> = new Map<string, CacheValue>();
+  private inFlight: Map<string, Subject<any>> = new Map<string, Subject<any>>();
+
+  public clear(key: string) {
+    if (this.inFlight.has(key)) {
+      this.inFlight.delete(key);
+    }
+    if (this.has(key)) {
+      this.cache.delete(key);
+    }
+  }
+
+  public get(key: string, fallback?: Observable<any>, maxAge: number = this.DEFAULT_MAX_AGE_S): Observable<any> | Subject<any> {
+    if (this.hasValidValue(key)) {
+      return Observable.of(this.cache.get(key).value);
+    }
+
+    if (this.inFlight.has(key)) {
+      return this.inFlight.get(key);
+    } else if (fallback && fallback instanceof Observable) {
+      this.inFlight.set(key, new Subject());
+      return fallback.do((value) => { this.set(key, value, maxAge); });
+    } else {
+      return Observable.throw(`Requested key ${key} is not available in Cache`);
+    }
+  }
+
+  public has(key: string) {
+    return this.cache.has(key);
+  }
+
+  public set(key: string, value: Observable<any>, maxAge: number = this.DEFAULT_MAX_AGE_S) {
+    this.cache.set(key, { value: value, expiry: Date.now() + maxAge });
+    this.notifyInFlight(key, value);
+  }
+
+  private hasValidValue(key: string) {
+    if (this.has(key)) {
+      if (this.cache.get(key).expiry < Date.now()) {
+        this.cache.delete(key);
+        return false;
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private notifyInFlight(key: string, value: any) {
+    if (this.inFlight.has(key)) {
+      const inFlight = this.inFlight.get(key);
+      const observersCount = inFlight.observers.length;
+      if (observersCount) {
+        inFlight.next(value);
+      }
+      inFlight.complete();
+      this.inFlight.delete(key);
+    }
+  }
+}

--- a/src/lib/modules/api/services/climate-model.service.spec.ts
+++ b/src/lib/modules/api/services/climate-model.service.spec.ts
@@ -1,11 +1,13 @@
 import { Observable } from 'rxjs/Rx';
 
 import { ClimateModelService } from './climate-model.service';
+import { APICacheService } from './api-cache.service';
 
 
 describe('ClimateModelService', () => {
 
     let service: ClimateModelService;
+    let cache: APICacheService;
 
     let apiHttpStub: any;
 
@@ -18,7 +20,8 @@ describe('ClimateModelService', () => {
             get: jasmine.createSpy('get').and.returnValue(
                 Observable.of({json: () => testResponse}))
         };
-      service = new ClimateModelService('http://example.com', apiHttpStub);
+      cache = new APICacheService();
+      service = new ClimateModelService('http://example.com', apiHttpStub, cache);
     });
 
     it('should have a list method', () => {

--- a/src/lib/modules/api/services/climate-model.service.ts
+++ b/src/lib/modules/api/services/climate-model.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Rx';
 import { ClimateModel } from '../models/climate-model.model';
 import { ApiHttp } from './api-http.interface';
 import { API_HOST, API_HTTP } from '../config';
+import { APICacheService } from './api-cache.service';
 
 /*
  * Climate Model Service
@@ -13,11 +14,13 @@ import { API_HOST, API_HTTP } from '../config';
 export class ClimateModelService {
 
   constructor(@Inject(API_HOST) private apiHost: string,
-              @Inject(API_HTTP) private apiHttp: ApiHttp) {}
+              @Inject(API_HTTP) private apiHttp: ApiHttp,
+              private cache: APICacheService) {}
 
   public list(): Observable<ClimateModel[]> {
     const url = this.apiHost + '/api/climate-model/';
-    return this.apiHttp.get(url).map(resp => resp.json() || [] as ClimateModel[]);
+    const request = this.apiHttp.get(url);
+    const response = this.cache.get('climate.api.climatemodel.list', request);
+    return response.map(resp => resp.json() || [] as ClimateModel[]);
   }
 }
-

--- a/src/lib/modules/api/services/dataset.service.ts
+++ b/src/lib/modules/api/services/dataset.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Rx';
 import { Dataset } from '../models/dataset.model';
 import { ApiHttp } from './api-http.interface';
 import { API_HOST, API_HTTP } from '../config';
+import { APICacheService } from './api-cache.service';
 
 /*
  * Dataset Service
@@ -13,10 +14,13 @@ import { API_HOST, API_HTTP } from '../config';
 export class DatasetService {
 
   constructor(@Inject(API_HOST) private apiHost: string,
-              @Inject(API_HTTP) private apiHttp: ApiHttp) {}
+              @Inject(API_HTTP) private apiHttp: ApiHttp,
+              private cache: APICacheService) {}
 
   public list(): Observable<Dataset[]> {
     const url = this.apiHost + '/api/dataset/';
-    return this.apiHttp.get(url).map(resp => resp.json() || [] as Dataset[]);
+    const request = this.apiHttp.get(url);
+    const response = this.cache.get('climate.api.dataset.list', request);
+    return response.map(resp => resp.json() || [] as Dataset[]);
   }
 }

--- a/src/lib/modules/api/services/historic-range.service.ts
+++ b/src/lib/modules/api/services/historic-range.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Rx';
 import { HistoricRange } from '../models/historic-range.model';
 import { ApiHttp } from './api-http.interface';
 import { API_HOST, API_HTTP } from '../config';
+import { APICacheService } from './api-cache.service';
 
 /*
  * Historic Range Service
@@ -13,10 +14,13 @@ import { API_HOST, API_HTTP } from '../config';
 export class HistoricRangeService {
 
   constructor(@Inject(API_HOST) private apiHost: string,
-              @Inject(API_HTTP) private apiHttp: ApiHttp) {}
+              @Inject(API_HTTP) private apiHttp: ApiHttp,
+              private cache: APICacheService) {}
 
   public list(): Observable<HistoricRange[]> {
     const url = this.apiHost + '/api/historic-range/';
-    return this.apiHttp.get(url).map(resp => resp.json() || [] as HistoricRange[]);
+    const request = this.apiHttp.get(url);
+    const response = this.cache.get('climate.api.historicrange.list', request);
+    return response.map(resp => resp.json() || [] as HistoricRange[]);
   }
 }

--- a/src/lib/modules/api/services/indicator.service.ts
+++ b/src/lib/modules/api/services/indicator.service.ts
@@ -20,6 +20,7 @@ import { isBasetempIndicator,
 
 import { ApiHttp } from './api-http.interface';
 import { API_HOST, API_HTTP } from '../config';
+import { APICacheService } from './api-cache.service';
 
 
 /*
@@ -30,7 +31,8 @@ import { API_HOST, API_HTTP } from '../config';
 export class IndicatorService {
 
   constructor(@Inject(API_HOST) private apiHost: string,
-              @Inject(API_HTTP) private apiHttp: ApiHttp) {}
+              @Inject(API_HTTP) private apiHttp: ApiHttp,
+              private cache: APICacheService) {}
 
   public getData(options: IndicatorRequestOpts) {
 
@@ -112,10 +114,8 @@ export class IndicatorService {
 
   public list(): Observable<Indicator[]> {
     const url = this.apiHost + '/api/indicator/';
-
-    return this.apiHttp.get(url).map(resp => {
-      const indicators: Indicator[] = resp.json() || [];
-      return indicators;
-    });
+    const request = this.apiHttp.get(url);
+    const response = this.cache.get('climate.api.indicator.list', request);
+    return response.map(resp => (resp.json() || []) as Indicator[]);
   }
 }

--- a/src/lib/modules/api/services/scenario.service.ts
+++ b/src/lib/modules/api/services/scenario.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Rx';
 import { Scenario } from '../models/scenario.model';
 import { ApiHttp } from './api-http.interface';
 import { API_HOST, API_HTTP } from '../config';
+import { APICacheService } from './api-cache.service';
 
 /*
  * Scenario Service
@@ -13,10 +14,13 @@ import { API_HOST, API_HTTP } from '../config';
 export class ScenarioService {
 
   constructor(@Inject(API_HOST) private apiHost: string,
-              @Inject(API_HTTP) private apiHttp: ApiHttp) {}
+              @Inject(API_HTTP) private apiHttp: ApiHttp,
+              private cache: APICacheService) {}
 
   public list(): Observable<Scenario[]> {
     const url = this.apiHost + '/api/scenario/';
-    return this.apiHttp.get(url).map(resp => resp.json() || [] as Scenario[]);
+    const request = this.apiHttp.get(url);
+    const response = this.cache.get('climate.api.scenario.list', request);
+    return response.map(resp => resp.json() || [] as Scenario[]);
   }
 }


### PR DESCRIPTION
## Overview

Use new cache service for the following calls:

- ClimateModelService.list()
- DatasetService.list()
- HistoricRangeService.list()
- ScenarioService.list()
- IndicatorService.list()

Could expand this later to cache to disk, or implement FIFO to
keep memory usage sensible. For now the limited usage of the
cache makes these optimizations unnecessary.

### Demo

![screen shot 2017-12-12 at 2 31 33 pm](https://user-images.githubusercontent.com/1818302/33904316-3480b9e8-df49-11e7-9940-99afb2969c71.png)

### Notes

Will remove console.log statements before merging. Left them in to demonstrate where caching is used.

I found a few different ways to implement caching and no good third party libraries that allowed for a sensible import. This seemed like the most flexible and least intrusive (in terms of having to modify existing code) option. 

## Testing Instructions

Ensure climate-change-lab is on latest develop.

Then in components run `yarn run build:library && npm pack`. Once that completes, switch to the lab repo and run: `npm install ../climate-change-components/climate-change-components-0.2.2.tgz && yarn serve`

Click around the lab interface. You should only see actual API requests the first time the application requests a particular endpoint for the calls noted in overview.

Closes #19 

