### PR TITLE
ModelModal options

### DIFF
--- a/src/lib/modules/charts/components/model-modal/model-modal.component.html
+++ b/src/lib/modules/charts/components/model-modal/model-modal.component.html
@@ -12,7 +12,7 @@
      aria-labelledby="modelOptions"
      aria-hidden="true"
      bsModal #smModal="bs-modal"
-     [config]="{backdrop: 'static'}"
+     [config]="modalOptions"
      (onShow)="modalShow()"
      (onHide)="modalHide()">
   <div class="modal-dialog modal-sm" role="document">

--- a/src/lib/modules/charts/components/model-modal/model-modal.component.ts
+++ b/src/lib/modules/charts/components/model-modal/model-modal.component.ts
@@ -3,6 +3,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { ClimateModel } from '../../../api/models/climate-model.model';
 import { ClimateModelService } from '../../../api/services/climate-model.service';
 import { Dataset } from '../../../api/models/dataset.model';
+import { ModalOptions } from 'ngx-bootstrap/modal';
 
 /*  Model Modal Component
     -- Requires input for selected dataset and models
@@ -20,17 +21,23 @@ import { Dataset } from '../../../api/models/dataset.model';
 })
 export class ModelModalComponent implements OnInit {
 
+    @Input() config: ModalOptions;
     @Input() dataset: Dataset;
     @Input() models: ClimateModel[];
+
     @Output() onModelsChanged = new EventEmitter<ClimateModel[]>();
 
     public buttonText: string;
     public climateModels: ClimateModel[] = [];
     public smModal: any;
+    public readonly DEFAULT_MODAL_OPTIONS = { backdrop: 'static' };
+
+    private modalOptions: ModalOptions;
 
     constructor(private climateModelService: ClimateModelService) {}
 
     ngOnInit() {
+        this.modalOptions = Object.assign({}, this.DEFAULT_MODAL_OPTIONS, this.config);
         this.getClimateModels();
     }
 

--- a/src/lib/modules/charts/components/model-modal/model-modal.component.ts
+++ b/src/lib/modules/charts/components/model-modal/model-modal.component.ts
@@ -8,8 +8,10 @@ import { ModalOptions } from 'ngx-bootstrap/modal';
 /*  Model Modal Component
     -- Requires input for selected dataset and models
     -- Emits selected model
+    -- Items passed to [config] input are merged with the component's DEFAULT_MODAL_OPTIONS
     Expected use:
         <ccc-model-modal
+            [config]="bsModalOptions"
             [dataset]="yourDataset"
             [models]="yourSelectedModels"
             (onModelsChanged)="modelsChanged($event)">


### PR DESCRIPTION
## Overview

Allows the user to specify the options to the ModelModalComponent. This is useful in some derived scenarios where the user would prefer more control over the display of the modal.

User provided modal options are merged with ModelModalComponent.DEFAULT_MODAL_OPTIONS.

### Demo

No visible changes expected

### Notes

The DEFAULT_MODAL_OPTIONS are the same as the previous static set of options within the component. This should not change anything user facing.


## Testing Instructions

Ensure climate-change-lab is on latest develop.

Then in components run yarn run build:library && npm pack. Once that completes, switch to the lab repo and run: npm install ../climate-change-components/climate-change-components-0.2.2.tgz && yarn serve

You should see no visible changes.

To further test user-provided options, you could apply this diff to lab:
```
diff --git a/src/app/lab/lab.component.html b/src/app/lab/lab.component.html
index 3d73b34..9b0fb69 100755
--- a/src/app/lab/lab.component.html
+++ b/src/app/lab/lab.component.html
@@ -37,7 +37,8 @@
             <!-- climate model selector -->
             <div class="control-group">
               <label>Models</label>
-              <ccc-model-modal [dataset]="project.project_data.dataset"
+              <ccc-model-modal [config]="{animated: false, backdrop: false}"
+                               [dataset]="project.project_data.dataset"
                                [models]="project.project_data.models"
                                (onModelsChanged)="modelsChanged($event)">
               </ccc-model-modal>
```
and then restart your lab dev server. You should see no animation when the modal is shown/hidden, and there should be no backdrop when the modal is opened.


Closes #20 

