### PR TITLE
Remove imports with side effects in IndicatorService

### DIFF
--- a/src/lib/modules/api/services/indicator.service.ts
+++ b/src/lib/modules/api/services/indicator.service.ts
@@ -1,8 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { RequestOptions, URLSearchParams } from '@angular/http';
 import { Observable, Observer } from 'rxjs/Rx';
-import 'rxjs/add/observable/of';
-import 'rxjs/Rx';
 
 import { Indicator } from '../models/indicator.model';
 import { IndicatorRequestOpts } from '../models/indicator-request-opts.model';


### PR DESCRIPTION
## Overview

Imports such as:
```
import 'rxjs/Rx/Observable';
```
cause side effects which include patching of the observable
prototype chain, causing checks such as `foo instanceof Observable` to
fail.

These imports are no longer necessary, and all import can be done
using ES6 non-default imports, such as:
```
import { Observable } from 'rxjs/Rx';
```
See https://github.com/angular/angular-cli/issues/3904 for
some more details on the problem.

### Notes

This issue didn't surface when testing via the lab, likely because that project uses some non-default imports as well. 

## Testing Instructions

Test lab normally via local npm install:
```
// this repo
yarn run build:library && npm pack
// lab repo
npm install ../climate-change-components/climate-change-components-0.2.3.tgz && yarn serve
```

Testing our other application is not nearly as straightfoward. Can send instructions to test that separately.

Will push a new version of the project when merged.

## Checklist
- [x] `yarn run serve` clean?
- [x] `yarn run build:prod` clean?
- [x] `yarn run lint` clean?

