### PR TITLE
Bugfix IndicatorService.getData sends empty models param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- IndicatorService.getData no longer passes an empty `models` query parameter
+
 ## [0.2.5]
 ### Fixed
 - Made ModelModalComponent.modalOptions public to fix AOT builds

--- a/src/lib/modules/api/services/indicator.service.ts
+++ b/src/lib/modules/api/services/indicator.service.ts
@@ -86,7 +86,7 @@ export class IndicatorService {
     if (options.params.years) {
       searchParams.append('years', options.params.years.join(','));
     }
-    if (options.params.climateModels) {
+    if (options.params.climateModels && options.params.climateModels.length) {
       searchParams.append('models', options.params.climateModels.map(m => m.name).join(','));
     }
     if (options.params.time_aggregation) {


### PR DESCRIPTION
## Overview

getData sent an empty `models=` param if the climateModels param passed to it was an empty array. The API doesn't like this, throwing errors such as `['Dataset LOCA has no data for model(s) ']`. This prevents the models param being sent if empty, allowing the API to default to the correct "all models" state.

### Demo

A series of requests made with this change applied. Note that none of them have an empty `models=` get param:

![screen shot 2018-01-04 at 3 25 01 pm](https://user-images.githubusercontent.com/1818302/34582886-892637e4-f163-11e7-837d-d0dcbe12e500.png)


## Testing Instructions

Testing is no longer straightforward and cannot be done via Lab because it uses an old version of components and requires other updates due to breaking changes. If you'd like to test, message me directly.

Closes #27 

