### PR TITLE
Remove unnecessary [models] input of ModelModalComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Breaking change
+- ModelModalComponent [models] @Input() removed
+### Fixed
+- IndicatorService.getData no longer passes an empty `models` query parameter
+- ModelModalComponent no longer unnecessarily requests data when opening modal
+
 ## [0.2.5]
 ### Fixed
 - Made ModelModalComponent.modalOptions public to fix AOT builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Breaking change
-- ModelModalComponent [models] @Input() removed
 ### Fixed
 - IndicatorService.getData no longer passes an empty `models` query parameter
 - ModelModalComponent no longer unnecessarily requests data when opening modal

--- a/src/lib/modules/api/services/indicator.service.ts
+++ b/src/lib/modules/api/services/indicator.service.ts
@@ -86,7 +86,7 @@ export class IndicatorService {
     if (options.params.years) {
       searchParams.append('years', options.params.years.join(','));
     }
-    if (options.params.climateModels) {
+    if (options.params.climateModels && options.params.climateModels.length) {
       searchParams.append('models', options.params.climateModels.map(m => m.name).join(','));
     }
     if (options.params.time_aggregation) {

--- a/src/lib/modules/charts/components/model-modal/model-modal.component.ts
+++ b/src/lib/modules/charts/components/model-modal/model-modal.component.ts
@@ -1,12 +1,17 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 
 import { ClimateModel } from '../../../api/models/climate-model.model';
 import { ClimateModelService } from '../../../api/services/climate-model.service';
 import { Dataset } from '../../../api/models/dataset.model';
 import { ModalOptions } from 'ngx-bootstrap/modal';
-
-import * as cloneDeep from 'lodash.clonedeep';
-import { SimpleChanges } from '@angular/core/src/metadata/lifecycle_hooks';
 
 /*  Model Modal Component
     -- Requires input for selected dataset and models


### PR DESCRIPTION
## Overview

Simplifies logic in ModelModalComponent and fixes bug where we unnecessarily made a getData call when opening the modal

Supersedes #31 by including that fix here since it's required for this change to work cleanly

### Demo

A screenshot of the network tab when opening an indicator chart. Note that there are no failing requests with `models=` nor are there the large number of duplicate requests there were before. Any request in this pane marked with `Initiator:other` is an OPTIONS request sent by the Chrome browser and shouldn't be counted as a request made by our code:

![screen shot 2018-01-05 at 2 11 38 pm](https://user-images.githubusercontent.com/1818302/34624219-80641d1e-f222-11e7-9dc3-d52fb79db276.png)

Associated UI result of the chart load above:

![screen shot 2018-01-05 at 2 11 31 pm](https://user-images.githubusercontent.com/1818302/34624234-8ee004a2-f222-11e7-868a-c525ef9b6b88.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

Testing is no longer straightforward and cannot be done via Lab because it uses an old version of components and requires other updates due to breaking changes. If you'd like to test, message me directly.

If testing, the following should be fixed:
- Far fewer, more consistent requests each time a indicator chart is opened
- No change to ModelModalComponent user-facing behavior
- No Indicator data request when the ModelModalComponent is opened
- No more transient "Dataset LOCA has no models" errors

Closes #27, Closes #28 


  