### PR TITLE
Update pull request template for library case

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,10 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include test case, and expected output
 
 ## Checklist
-- [ ] `yarn run serve` clean?
-- [ ] `yarn run build:prod` clean?
 - [ ] `yarn run lint` clean?
+- [ ] `yarn run build:library` clean?
+- [ ] `npm pack` clean?
+- [ ] `CHANGELOG.md` updated?
 
 Closes|Fixes #XXX
 


### PR DESCRIPTION
## Overview

Corrects the pull request template to be valid for npm libraries and adds an item for updating `CHANGELOG.md`. This PR does not add a version-bump item to the checklist, as we should probably do that while making a release, not upon merge of a feature. Let's discuss if there's a case for updating version in a PR that I'm missing.

Closes #10 

