### PR TITLE
Initialize model modal with empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Upcoming release
+### Fixed
+- Initialize model modal with empty list
+
 ## 0.2.8
 ### Fixed
 - Re-add removed ModelModalComponent.modalShow method to fix stale model list on modal open

--- a/src/lib/modules/charts/components/model-modal/model-modal.component.ts
+++ b/src/lib/modules/charts/components/model-modal/model-modal.component.ts
@@ -40,6 +40,7 @@ export class ModelModalComponent implements OnInit {
 
     ngOnInit() {
         this.modalOptions = Object.assign({}, this.DEFAULT_MODAL_OPTIONS, this.config);
+        this.climateModels = [];  // initialize with empty list while modal loads
         this.getClimateModels();
     }
 


### PR DESCRIPTION
## Overview

Initialize model modal with This stops `this.climateModels` from being undefined and raising errors
while the list of available models loads.

## Testing Instructions

 * Run `yarn build:library`
 * Run `npm pack`
 * Test in downstream project

## Checklist
- [X] `yarn run lint` clean?
- [X] `yarn run build:library` clean?
- [X] `npm pack` clean?
- [X] `CHANGELOG.md` updated?

Connects #33. Will close issue upon release.

