### PR TITLE
Add headless Chrome workaround in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
  - 6
+sudo: required
+addons:
+  chrome: stable
 
 script:
  - yarn run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Upcoming Release
+## 0.2.10
+- Fix broken build caused by Travis regression
+
 ## 0.2.9
 ### Fixed
 - Initialize model modal with empty list


### PR DESCRIPTION
## Overview

A regression in Travis (https://github.com/travis-ci/travis-ci/issues/8836) breaks builds. This PR adds a workaround suggested in the issue.
