### PR TITLE
Use scenario alias as toggle button label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Upcoming release
+- Use scenario alias as toggle button label
+
 ## 0.2.11
 ### Fixed
 - Switched to using peerDependencies for Angular & Angular libraries

--- a/src/lib/modules/charts/charts.module.ts
+++ b/src/lib/modules/charts/charts.module.ts
@@ -4,7 +4,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import {
   BsDropdownModule,
-  ModalModule
+  ModalModule,
+  TooltipModule
 } from 'ngx-bootstrap';
 
 import { DatasetToggleComponent } from './components/dataset-toggle/dataset-toggle.component';
@@ -26,7 +27,8 @@ import {
     FormsModule,
     ReactiveFormsModule,
     BsDropdownModule.forRoot(),
-    ModalModule.forRoot()
+    ModalModule.forRoot(),
+    TooltipModule.forRoot()
   ],
   declarations: [
     BasetempComponent,

--- a/src/lib/modules/charts/components/scenario-toggle/scenario-toggle.component.html
+++ b/src/lib/modules/charts/components/scenario-toggle/scenario-toggle.component.html
@@ -2,7 +2,8 @@
   <button class="button"
           *ngFor="let s of scenarios"
           [ngClass]="{'active': s.name === scenario.name}"
-          (click)="onScenarioClicked(s, $event)">
-    {{ s.label }}
+          (click)="onScenarioClicked(s, $event)"
+          tooltip="{{ s.label }}">
+    {{ s.alias }}
   </button>
 </div>


### PR DESCRIPTION
## Overview
The alias is a more human-friendly name for the scenario. The technical name is now used in a tooltip.

### Notes

Relies on https://github.com/azavea/climate-change-api/pull/797

## Testing Instructions

Tested through https://github.com/azavea/temperate/pull/586

## Checklist
- [X] `yarn run lint` clean?
- [X] `yarn run build:library` clean?
- [X] `npm pack` clean?
- [X] `CHANGELOG.md` updated?

Connects to https://github.com/azavea/temperate/issues/295