### PR TITLE
Export cache service for public use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Export cache service for public use
+
 ## 0.2.13
 - Export ModelModalComponent for direct use outside of this library
 - Rework ModelModalComponent filtering and hiding behavior to avoid triggering updates when parent chart has been removed from DOM

--- a/src/lib/modules/api/index.ts
+++ b/src/lib/modules/api/index.ts
@@ -24,6 +24,7 @@ export { TimeAggParam } from './models/time-agg-param.enum';
 
 export { ApiHttp } from './services/api-http.interface';
 
+export { APICacheService } from './services/api-cache.service';
 export { ChartService } from './services/chart.service';
 export { CityService } from './services/city.service';
 export { ClimateModelService } from './services/climate-model.service';


### PR DESCRIPTION
## Overview

The cache service created here works well and should be available for reuse in other contexts.

## Testing Instructions

- This change is needed to use the CCC cache in Temperate. I've been working with this change for the past two days, and have verified that it works. I'll create a release after this is approved.

## Checklist
- [X] `yarn run lint` clean?
- [X] `yarn run build:library` clean?
- [X] `npm pack` clean?
- [X] `CHANGELOG.md` updated?

Related to https://github.com/azavea/temperate/issues/972