### PR TITLE
Add IE/Edge compatibility to line graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.2.15
+- Make line graph data scrubber compatible for evergreen browsers
+
 ## 0.2.14
 - Export cache service for public use
 

--- a/src/lib/modules/charts/components/line-graph/line-graph.component.ts
+++ b/src/lib/modules/charts/components/line-graph/line-graph.component.ts
@@ -37,288 +37,291 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
 
   public extractedData: Array<MultiDataPoint>;
 
-  private host;                          // D3 object referebcing host dom object
-  private svg;                           // SVG in which we will print our chart
-  private margin;                        // Space between svg borders and the actual chart graphic
-  private width;                         // Component width
-  private height;                        // Component height
-  private xScale;                        // D3 scale in X
-  private yScale;                        // D3 scale in Y
-  private htmlElement;                   // Host HTMLElement
-  private valueline;                     // Base for a chart line
-  private xRange: Array<Date>;           // Min, max date range
-  private xData: Array<number>;          // Stores x axis data as integers rather than dates,
-                                         // necessary for trendline math
-  private yData: Array<number>;          // Stores primary y axis data, multi-use
-  private timeFormat: string;            // Date formatting for x axis labels (e.g, '%Y-%m')
-  private scrubber;                      // Lump of scrubber elements
-  private id: string;                    // Randomly generated int # used to distinguish the chart
-                                         // for drawing and isolated chart scrubber.
-                                         // Not a perfect solution should the random int and
-                                         // indicator be the same. However, this is quite unlikely
-                                         // (1/10000, and even less likely by way of app use)
+  private host;                      // D3 object referebcing host dom object
+  private svg;                       // SVG in which we will print our chart
+  private margin;                    // Space between svg borders and the actual chart graphic
+  private width;                     // Component width
+  private height;                    // Component height
+  private xScale;                    // D3 scale in X
+  private yScale;                    // D3 scale in Y
+  private htmlElement;               // Host HTMLElement
+  private valueline;                 // Base for a chart line
+  private xRange: Array<Date>;       // Min, max date range
+  private xData: Array<number>;      // Stores x axis data as integers rather than dates,
+                                     // necessary for trendline math
+  private yData: Array<number>;      // Stores primary y axis data, multi-use
+  private timeFormat: string;        // Date formatting for x axis labels (e.g, '%Y-%m')
+  private scrubber;                  // Lump of scrubber elements
+  private id: string;                // Randomly generated int # used to distinguish the chart
+                                     // for drawing and isolated chart scrubber.
+                                     // Not a perfect solution should the random int and
+                                     // indicator be the same. However, this is quite unlikely
+                                     // (1/10000, and even less likely by way of app use)
 
   /* We request angular for the element reference
   * and then we create a D3 Wrapper for our host element
   */
   constructor(private element: ElementRef, private chartService: ChartService) {
-      this.htmlElement = this.element.nativeElement;
-      this.host = D3.select(this.element.nativeElement);
+    this.htmlElement = this.element.nativeElement;
+    this.host = D3.select(this.element.nativeElement);
   }
 
   @HostListener('window:resize', ['$event'])
   onResize() {
-      this.ngOnChanges();
+    this.ngOnChanges();
   }
 
   // If the chart is being hovered over, handle mouse movements
   @HostListener('mousemove', ['$event'])
   onMouseMove(event) {
-      // for single-chart scrubber
-      if (this.hover) {
-          this.redrawScrubber(event);
-      }
+    // for single-chart scrubber
+    if (this.hover) {
+      this.redrawScrubber(event);
+    }
   }
 
   /* Executes on every @Input change */
   ngOnChanges(): void {
-      this.composeLineGraph();
+    this.composeLineGraph();
   }
 
   ngAfterContentInit(): void {
-      this.composeLineGraph();
+    this.composeLineGraph();
   }
 
   private composeLineGraph(): void {
-      if (!this.data || this.data.length === 0) { return; }
-      this.filterData();
-      this.setup();
-      this.buildSVG();
-      this.setLineScales();
-      this.drawGrid();
-      this.drawMinMaxBand();
-      this.drawXAxis();
-      this.drawYAxis();
-      this.drawAvgLine();
-      this.drawScrubber();
+    if (!this.data || this.data.length === 0) { return; }
+    this.filterData();
+    this.setup();
+    this.buildSVG();
+    this.setLineScales();
+    this.drawGrid();
+    this.drawMinMaxBand();
+    this.drawXAxis();
+    this.drawYAxis();
+    this.drawAvgLine();
+    this.drawScrubber();
   }
 
   private filterData(): void {
-      // Preserves parent data by fresh copying indicator data that will undergo processing
-      if (this.data && this.data[0] && this.data[0].data) {
-          this.extractedData = cloneDeep(this.data[0]['data']);
-      } else {
-          this.extractedData = [];
-      }
-      // Remove empty day in non-leap years (affects only daily data)
-      if (this.extractedData[365] && this.extractedData[365]['date'] == null) {
-          this.extractedData.pop();
-      }
-      this.timeFormat = this.data[0].time_format;
+    // Preserves parent data by fresh copying indicator data that will undergo processing
+    if (this.data && this.data[0] && this.data[0].data) {
+      this.extractedData = cloneDeep(this.data[0]['data']);
+    } else {
+      this.extractedData = [];
+    }
+    // Remove empty day in non-leap years (affects only daily data)
+    if (this.extractedData[365] && this.extractedData[365]['date'] == null) {
+      this.extractedData.pop();
+    }
+    this.timeFormat = this.data[0].time_format;
   }
 
   /* Will setup the chart basics */
   private setup(): void {
-      this.margin = { top: 10, right: 50, bottom: 30, left: 60 };
-      this.width = $('.chart').width() - this.margin.left - this.margin.right;
-      this.height = $('.line-graph').height() - this.margin.top - this.margin.bottom;
-      this.xScale = D3.scaleTime().range([0, this.width]);
-      this.yScale = D3.scaleLinear().range([this.height, 0]);
-      this.id = this.indicator.name + (Math.round(Math.random() * 10000)).toString();
+    this.margin = { top: 10, right: 50, bottom: 30, left: 60 };
+    this.width = $('.chart').width() - this.margin.left - this.margin.right;
+    this.height = $('.line-graph').height() - this.margin.top - this.margin.bottom;
+    this.xScale = D3.scaleTime().range([0, this.width]);
+    this.yScale = D3.scaleLinear().range([this.height, 0]);
+    this.id = this.indicator.name + (Math.round(Math.random() * 10000)).toString();
   }
 
   /* Will build the SVG Element */
   private buildSVG(): void {
-      this.host.html('');
-      this.svg = this.host.append('svg')
-        .attr('id', 'chart-' + this.indicator.name)
-        .attr('width', this.width + this.margin.left + this.margin.right)
-        .attr('height', this.height + this.margin.top + this.margin.bottom)
-        .append('g')
-        .attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')');
+    this.host.html('');
+    this.svg = this.host.append('svg')
+      .attr('id', 'chart-' + this.indicator.name)
+      .attr('width', this.width + this.margin.left + this.margin.right)
+      .attr('height', this.height + this.margin.top + this.margin.bottom)
+      .append('g')
+      .attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')');
   }
 
   // Set axis and line scales
   private setLineScales(): void {
-      // Sort data by date ascending
-      this.extractedData.sort(function(a, b) { return +a.date - +b.date; });
-      // Parse out avg data for ease of use later
-      this.yData = this.extractedData.map(d => d.values.avg);
+    // Sort data by date ascending
+    this.extractedData.sort(function(a, b) { return +a.date - +b.date; });
+    // Parse out avg data for ease of use later
+    this.yData = this.extractedData.map(d => d.values.avg);
 
-      this.xRange = D3.extent(this.extractedData, d => d.date);
-      this.xScale.domain(this.xRange);
+    this.xRange = D3.extent(this.extractedData, d => d.date);
+    this.xScale.domain(this.xRange);
 
-      // Adjust y scale, prettify graph
-      const minY = D3.min(this.extractedData.map(d => d.values.min));
-      const maxY = D3.max(this.extractedData.map(d => d.values.max));
-      // Note: 5 as default is arbitrary
-      const yPad = (maxY - minY) > 0 ? (maxY - minY) * 1 / 3 : 5;
-      // if minY is 0, keep it that way
-      this.yScale.domain([minY === 0 ? minY : minY - yPad, maxY + yPad]);
+    // Adjust y scale, prettify graph
+    const minY = D3.min(this.extractedData.map(d => d.values.min));
+    const maxY = D3.max(this.extractedData.map(d => d.values.max));
+    // Note: 5 as default is arbitrary
+    const yPad = (maxY - minY) > 0 ? (maxY - minY) * 1 / 3 : 5;
+    // if minY is 0, keep it that way
+    this.yScale.domain([minY === 0 ? minY : minY - yPad, maxY + yPad]);
 
-      // Expects line data as DataPoint[]
-      this.valueline = D3.line()
-        .x(d => this.xScale(d.date))
-        .y(d => this.yScale(d.value));
+    // Expects line data as DataPoint[]
+    this.valueline = D3.line()
+    .x(d => this.xScale(d.date))
+    .y(d => this.yScale(d.value));
   }
 
   /* Will draw the X Axis */
   private drawXAxis(): void {
-      this.svg.append('g')
-        .attr('transform', 'translate(0,' + this.height + ')')
-        .attr('class', 'axis')
-        .call(D3.axisBottom(this.xScale)
-            .ticks(5)
-            .tickSize(0)
-            .tickFormat(D3.timeFormat(this.timeFormat)))
-        .selectAll('text')
-        .attr('y', 10);
+    this.svg.append('g')
+      .attr('transform', 'translate(0,' + this.height + ')')
+      .attr('class', 'axis')
+      .call(D3.axisBottom(this.xScale)
+        .ticks(5)
+        .tickSize(0)
+        .tickFormat(D3.timeFormat(this.timeFormat)))
+      .selectAll('text')
+      .attr('y', 10);
   }
 
   /* Will draw the Y Axis */
   private drawYAxis(): void {
-      this.svg.append('g')
-        .attr('class', 'axis')
-        .call(D3.axisLeft(this.yScale)
-            .tickSize(0)
-            .ticks(5))
-        .selectAll('text')
-        .attr('x', -10);
+    this.svg.append('g')
+      .attr('class', 'axis')
+      .call(D3.axisLeft(this.yScale)
+        .tickSize(0)
+        .ticks(5))
+      .selectAll('text')
+      .attr('x', -10);
   }
 
   private drawGrid(): void {
-      this.svg.append('g')
-          .attr('class', 'grid line')
-          .call(this.makeXGridlines()
-              .tickSize(this.height)
-              .tickFormat(''));
+    this.svg.append('g')
+      .attr('class', 'grid line')
+      .call(this.makeXGridlines()
+        .tickSize(this.height)
+        .tickFormat(''));
 
-      this.svg.append('g')
-          .attr('class', 'grid line')
-          .call(this.makeYGridlines()
-              .tickSize(-this.width)
-              .tickFormat(''));
+    this.svg.append('g')
+      .attr('class', 'grid line')
+      .call(this.makeYGridlines()
+        .tickSize(-this.width)
+        .tickFormat(''));
   }
 
   private makeXGridlines() {
-      return D3.axisBottom(this.xScale)
-          .ticks(5);
+    return D3.axisBottom(this.xScale)
+      .ticks(5);
   }
 
   private makeYGridlines() {
-      return D3.axisLeft(this.yScale)
-          .ticks(5);
+    return D3.axisLeft(this.yScale)
+      .ticks(5);
   }
 
   /* Draw line */
   private drawAvgLine(): void {
-      const data = this.extractedData.map(d => ({'date': d.date, 'value': d.values.avg }));
-      this.drawLine(data, 'line');
+    const data = this.extractedData.map(d => ({'date': d.date, 'value': d.values.avg }));
+    this.drawLine(data, 'line');
   }
 
   private drawMinMaxBand(): void {
-      const area = D3.area()
-          .x(d => this.xScale(d.date))
-          .y0(d => this.yScale(d.min))
-          .y1(d => this.yScale(d.max));
+    const area = D3.area()
+      .x(d => this.xScale(d.date))
+      .y0(d => this.yScale(d.min))
+      .y1(d => this.yScale(d.max));
 
-      const minMaxData = this.extractedData.map(d => ({'date': d.date,
-                                                       'min': d.values.min,
-                                                       'max': d.values.max}));
+    const minMaxData = this.extractedData.map(d => ({'date': d.date,
+                                                     'min': d.values.min,
+                                                     'max': d.values.max}));
 
-      // Draw min/max area
-      this.svg.append('path')
-        .data([minMaxData])
-        .attr('class', 'area')
-        .attr('d', area);
+    // Draw min/max area
+    this.svg.append('path')
+      .data([minMaxData])
+      .attr('class', 'area')
+      .attr('d', area);
   }
 
 
   private drawScrubber(): void {
-      // Vertical scrub line. Exists outside scrubber cluster because it moves independently
-      this.svg.append('line')
-          .attr('class', 'scrubline' + ' ' + this.id)
-          .attr('x1', 0).attr('x2', 0)
-          .attr('y1', 0).attr('y2', this.height)
-          .classed('hidden', true);
+    // Vertical scrub line. Exists outside scrubber cluster because it moves independently
+    this.svg.append('line')
+      .attr('class', 'scrubline' + ' ' + this.id)
+      .attr('x1', 0).attr('x2', 0)
+      .attr('y1', 0).attr('y2', this.height)
+      .classed('hidden', true);
 
-      // Other scrubber elements
-      this.scrubber = this.svg.append('g')
-          .attr('class', this.id)
-          .classed('hidden', true);
+    // Other scrubber elements
+    this.scrubber = this.svg.append('g')
+      .attr('class', this.id)
+      .classed('hidden', true);
 
-      this.scrubber.append('circle')
-          .attr('r', 4.5);
+    this.scrubber.append('circle')
+      .attr('r', 4.5);
 
-      this.scrubber.append('rect')
-          .attr('class', 'scrubber-box' + ' ' + this.id)
-          .attr('height', 20);
+    this.scrubber.append('rect')
+      .attr('class', 'scrubber-box' + ' ' + this.id)
+      .attr('height', 20);
 
-      this.scrubber.append('text')
-          .attr('class', 'scrubber-text' + ' ' + this.id);
+    this.scrubber.append('text')
+      .attr('class', 'scrubber-text' + ' ' + this.id);
 
-      // Scrubber sensory zone (set to size of graph) intentionally drawn last
-      // It overlays all other svg elements for uncompromised mouseover detection
-      this.svg.append('rect')
-          .attr('id', 'overlay')
-          .attr('height', this.height)
-          .attr('width', this.width);
+    // Scrubber sensory zone (set to size of graph) intentionally drawn last
+    // It overlays all other svg elements for uncompromised mouseover detection
+    this.svg.append('rect')
+      .attr('id', 'overlay')
+      .attr('height', this.height)
+      .attr('width', this.width);
 
-      // Toggle scrubber visibility
-      this.hover ? $('.' + this.id).toggleClass('hidden', false) :
-          $('.' + this.id).toggleClass('hidden', true);
+    // Toggle scrubber visibility
+    this.hover ? $('.' + this.id).toggleClass('hidden', false) :
+      $('.' + this.id).toggleClass('hidden', true);
   }
 
   private redrawScrubber(event) {
-      let xPos = event.offsetX - this.margin.left;
-      // Firefox handles event positioning differently than Chrome, Safari
-      if (navigator && navigator.userAgent.toLowerCase().indexOf('firefox') !== -1) {
-          xPos = event.offsetX;
+    let xPos = event.offsetX;
+    // Firefox, IE & Edge handle event positioning differently than Chrome, Safari
+    if (navigator) {
+      const browser = navigator.userAgent.toLowerCase();
+      if (browser.indexOf('chrome') > -1 || browser.indexOf('safari') > -1) {
+        xPos = event.offsetX - this.margin.left;
       }
+    }
 
-      // Quit if mouse outside chart bounds; eliminate flashing misbehavior in Firefox too
-      if (xPos < 0 || xPos > this.width) { return; }
+    // Quit if mouse outside chart bounds; eliminate flashing misbehavior in Firefox too
+    if (xPos < 0 || xPos > this.width) { return; }
 
-      // Default round down position to existing time point
-      // Note the +unary operator before dates. Converts dates to numbers to quell tslinter
-      const bisectDate = D3.bisector(function(datum) { return datum.date; }).left;
-      const x0 = this.xScale.invert(xPos),
-          i = +bisectDate(this.extractedData, x0, 1),
-          d0 = this.extractedData[i - 1],
-          d1 = this.extractedData[i];
-      let d: number;
+    // Default round down position to existing time point
+    // Note the +unary operator before dates. Converts dates to numbers to quell tslinter
+    const bisectDate = D3.bisector(function(datum) { return datum.date; }).left;
+    const x0 = this.xScale.invert(xPos),
+      i = +bisectDate(this.extractedData, x0, 1),
+      d0 = this.extractedData[i - 1],
+      d1 = this.extractedData[i];
+    let d: number;
 
-      // Prevent error leaving graph
-      if (d0 && d1) {
-          d = x0 - +d0.date > +d1.date - x0 ? i : i - 1;
-      } else {
-          d = i - 1;
-      }
+    // Prevent error leaving graph
+    if (d0 && d1) {
+      d = x0 - +d0.date > +d1.date - x0 ? i : i - 1;
+    } else {
+      d = i - 1;
+    }
 
-      const yDatum = this.yData[d];
+    const yDatum = this.yData[d];
 
-      // Move scubber elements
-      this.scrubber.attr('transform', 'translate(' + xPos + ',' + this.yScale(yDatum) + ')');
-      this.svg.selectAll('.scrubline').attr('transform', 'translate(' + xPos + ',' + 0 + ')');
+    // Move scubber elements
+    this.scrubber.attr('transform', 'translate(' + xPos + ',' + this.yScale(yDatum) + ')');
+    this.svg.selectAll('.scrubline').attr('transform', 'translate(' + xPos + ',' + 0 + ')');
 
-      // Update scrubber text
-      const labelText = yDatum.toFixed(2) + ' ' + this.unit;
-      const textSVG = D3.select('.scrubber-text.' + this.id).text(labelText);
+    // Update scrubber text
+    const labelText = yDatum.toFixed(2) + ' ' + this.unit;
+    const textSVG = D3.select('.scrubber-text.' + this.id).text(labelText);
 
-      // Center text
-      const labelWidth = textSVG.node().getBBox().width;
-      textSVG.attr('transform', 'translate(' + -labelWidth / 2 + ',' + -15 + ')');
+    // Center text
+    const labelWidth = textSVG.node().getBBox().width;
+    textSVG.attr('transform', 'translate(' + -labelWidth / 2 + ',' + -15 + ')');
 
-      // Update text box length
-      D3.select('.scrubber-box.' + this.id)
-          .attr('width', labelWidth + 10)
-          .attr('transform', 'translate(' + -(labelWidth / 2 + 5) + ',' + -30 + ')');
+    // Update text box length
+    D3.select('.scrubber-box.' + this.id)
+      .attr('width', labelWidth + 10)
+      .attr('transform', 'translate(' + -(labelWidth / 2 + 5) + ',' + -30 + ')');
   }
 
   private drawLine(data: Array<DataPoint>, className: string): void {
-      this.svg.append('path')
-          .data([data])
-          .attr('class', className)
-          .attr('d', this.valueline);
+    this.svg.append('path')
+      .data([data])
+      .attr('class', className)
+      .attr('d', this.valueline);
   }
 }

--- a/src/lib/modules/charts/components/line-graph/line-graph.component.ts
+++ b/src/lib/modules/charts/components/line-graph/line-graph.component.ts
@@ -270,12 +270,14 @@ export class LineGraphComponent implements OnChanges, AfterContentInit {
   }
 
   private redrawScrubber(event) {
-    let xPos = event.offsetX;
+    let xPos = event.offsetX - this.margin.left;
     // Firefox, IE & Edge handle event positioning differently than Chrome, Safari
     if (navigator) {
       const browser = navigator.userAgent.toLowerCase();
-      if (browser.indexOf('chrome') > -1 || browser.indexOf('safari') > -1) {
-        xPos = event.offsetX - this.margin.left;
+      if (browser.indexOf('trident') > -1 || // trident is the identifier for IE11
+          browser.indexOf('edge') > -1 ||
+          browser.indexOf('firefox') > -1) {
+        xPos = event.offsetX;
       }
     }
 


### PR DESCRIPTION
## Overview

The line graph scrubber was offset in IE and Edge, but we need to account for those browser users.

Line 273 is the code block that changed functionally.
The rest is just spacing clean up that was driving me nuts.

## Testing Instructions

I had made [a plunkr of the line graph](https://plnkr.co/edit/9xmWDeHHuo2pwl0tVyKf) with some basic and dummy data that I used to test this change. Try it out in different browsers to see it scrubs correctly with regard to cursor position. Note, the scrubber doesn't follow the line, but rather data points broken at their midpoints. 

## Checklist
- [x] `yarn run lint` clean?
- [x] `yarn run build:library` clean?
- [x] `npm pack` clean?
- [x] `CHANGELOG.md` updated?

Closes #43 

