### PR TITLE
Add distance parameter for API requests

### DIFF
--- a/src/lib/modules/api/index.ts
+++ b/src/lib/modules/api/index.ts
@@ -1,25 +1,46 @@
 
 export { ApiModule } from './api.module';
 
-export { BasetempIndicatorQueryParams } from './models/basetemp-indicator-query-params.model';
+export {
+  BasetempIndicatorQueryParams,
+  BasetempIndicatorDistanceQueryParams,
+} from './models/basetemp-indicator-query-params.model';
 export { ChartData } from './models/chart-data.model';
 export { Chart } from './models/chart.model';
 export { City } from './models/city.model';
 export { ClimateModel } from './models/climate-model.model';
 export { DataPoint } from './models/data-point.model';
 export { Dataset } from './models/dataset.model';
-export { HistoricIndicatorQueryParams } from './models/historic-indicator-query-params.model';
+export {
+  HistoricIndicatorDistanceQueryParams,
+  HistoricIndicatorQueryParams,
+} from './models/historic-indicator-query-params.model';
 export { HistoricRange } from './models/historic-range.model';
 export { IndicatorParameter } from './models/indicator-parameter.model';
-export { IndicatorQueryParams } from './models/indicator-query-params.model';
-export { IndicatorRequestOpts } from './models/indicator-request-opts.model';
+export {
+  IndicatorDistanceQueryParams,
+  IndicatorQueryParams
+} from './models/indicator-query-params.model';
+export {
+  IndicatorDistanceRequestOpts,
+  IndicatorRequestOpts,
+} from './models/indicator-request-opts.model';
 export { Indicator } from './models/indicator.model';
 export { MultiDataPoint } from './models/multi-data-point.model';
 export { HistoricPercentileParam, HistoricPercentileParamOptions } from './models/historic-percentile-param.enum';
-export { PercentileIndicatorQueryParams } from './models/percentile-indicator-query-params.model';
-export { PercentileHistoricIndicatorQueryParams } from './models/percentile-historic-indicator-query-params.model';
+export {
+  PercentileIndicatorDistanceQueryParams,
+  PercentileIndicatorQueryParams,
+} from './models/percentile-indicator-query-params.model';
+export {
+  PercentileHistoricIndicatorDistanceQueryParams,
+  PercentileHistoricIndicatorQueryParams,
+} from './models/percentile-historic-indicator-query-params.model';
 export { Scenario } from './models/scenario.model';
-export { ThresholdIndicatorQueryParams } from './models/threshold-indicator-query-params.model';
+export {
+  ThresholdIndicatorDistanceQueryParams,
+  ThresholdIndicatorQueryParams
+} from './models/threshold-indicator-query-params.model';
 export { TimeAggParam } from './models/time-agg-param.enum';
 
 export { ApiHttp } from './services/api-http.interface';

--- a/src/lib/modules/api/models/basetemp-indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/basetemp-indicator-query-params.model.ts
@@ -1,6 +1,12 @@
-import { IndicatorQueryParams } from './indicator-query-params.model';
+import {
+  IndicatorQueryParams,
+  IndicatorDistanceQueryParams,
+} from './indicator-query-params.model';
 
 export interface BasetempIndicatorQueryParams extends IndicatorQueryParams {
   basetemp: Number;
   basetemp_units: string;
 }
+
+export interface BasetempIndicatorDistanceQueryParams
+  extends IndicatorDistanceQueryParams, BasetempIndicatorQueryParams { }

--- a/src/lib/modules/api/models/historic-indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/historic-indicator-query-params.model.ts
@@ -1,5 +1,11 @@
-import { IndicatorQueryParams } from './indicator-query-params.model';
+import {
+  IndicatorQueryParams,
+  IndicatorDistanceQueryParams,
+} from './indicator-query-params.model';
 
 export interface HistoricIndicatorQueryParams extends IndicatorQueryParams {
   historic_range: Number;
 }
+
+export interface HistoricIndicatorDistanceQueryParams
+  extends IndicatorDistanceQueryParams, HistoricIndicatorQueryParams { }

--- a/src/lib/modules/api/models/indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/indicator-query-params.model.ts
@@ -9,3 +9,7 @@ export interface IndicatorQueryParams {
   agg?: string;
   unit?: string;
 }
+
+export interface IndicatorDistanceQueryParams extends IndicatorQueryParams {
+  distance?: number;
+}

--- a/src/lib/modules/api/models/indicator-request-opts.model.ts
+++ b/src/lib/modules/api/models/indicator-request-opts.model.ts
@@ -1,9 +1,18 @@
 import { Indicator } from './indicator.model';
-import { IndicatorQueryParams } from './indicator-query-params.model';
+import {
+  IndicatorDistanceQueryParams,
+  IndicatorQueryParams,
+} from './indicator-query-params.model';
 import { Scenario } from './scenario.model';
 
 export interface IndicatorRequestOpts {
   indicator: Indicator;
   scenario: Scenario;
   params: IndicatorQueryParams;
+}
+
+export interface IndicatorDistanceRequestOpts {
+  indicator: Indicator;
+  scenario: Scenario;
+  params: IndicatorDistanceQueryParams;
 }

--- a/src/lib/modules/api/models/percentile-historic-indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/percentile-historic-indicator-query-params.model.ts
@@ -1,7 +1,13 @@
-import { IndicatorQueryParams } from './indicator-query-params.model';
+import {
+  IndicatorQueryParams,
+  IndicatorDistanceQueryParams,
+} from './indicator-query-params.model';
 import { HistoricPercentileParam } from './historic-percentile-param.enum';
 
 export interface PercentileHistoricIndicatorQueryParams extends IndicatorQueryParams {
   historic_range: Number;
   percentile: HistoricPercentileParam;
 }
+
+export interface PercentileHistoricIndicatorDistanceQueryParams
+  extends IndicatorDistanceQueryParams, PercentileHistoricIndicatorQueryParams { }

--- a/src/lib/modules/api/models/percentile-indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/percentile-indicator-query-params.model.ts
@@ -1,5 +1,11 @@
-import { IndicatorQueryParams } from './indicator-query-params.model';
+import {
+  IndicatorQueryParams,
+  IndicatorDistanceQueryParams,
+} from './indicator-query-params.model';
 
 export interface PercentileIndicatorQueryParams extends IndicatorQueryParams {
   percentile: number;
 }
+
+export interface PercentileIndicatorDistanceQueryParams
+  extends IndicatorDistanceQueryParams, PercentileIndicatorQueryParams { }

--- a/src/lib/modules/api/models/threshold-indicator-query-params.model.ts
+++ b/src/lib/modules/api/models/threshold-indicator-query-params.model.ts
@@ -1,7 +1,13 @@
-import { IndicatorQueryParams } from './indicator-query-params.model';
+import {
+  IndicatorQueryParams,
+  IndicatorDistanceQueryParams,
+} from './indicator-query-params.model';
 
 export interface ThresholdIndicatorQueryParams extends IndicatorQueryParams {
   threshold: Number;
   threshold_units: string;
   threshold_comparator: string;
 }
+
+export interface ThresholdIndicatorDistanceQueryParams
+  extends IndicatorDistanceQueryParams, ThresholdIndicatorQueryParams { }

--- a/src/lib/modules/api/services/indicator.service.ts
+++ b/src/lib/modules/api/services/indicator.service.ts
@@ -5,7 +5,14 @@ import { Point } from 'geojson';
 
 import { City } from '../models/city.model';
 import { Indicator } from '../models/indicator.model';
-import { IndicatorRequestOpts } from '../models/indicator-request-opts.model';
+import {
+  IndicatorQueryParams,
+  IndicatorDistanceQueryParams,
+} from '../models/indicator-query-params.model';
+import {
+  IndicatorRequestOpts,
+  IndicatorDistanceRequestOpts,
+} from '../models/indicator-request-opts.model';
 import { ThresholdIndicatorQueryParams } from '../models/threshold-indicator-query-params.model';
 import { BasetempIndicatorQueryParams } from '../models/basetemp-indicator-query-params.model';
 import { HistoricIndicatorQueryParams } from '../models/historic-indicator-query-params.model';
@@ -39,7 +46,7 @@ export class IndicatorService {
     return this.makeDataRequest(url, options);
   }
 
-  public getDataForLatLon(point: Point, options: IndicatorRequestOpts) {
+  public getDataForLatLon(point: Point, options: IndicatorDistanceRequestOpts) {
     const url = `${this.apiHost}/api/climate-data/${point.coordinates[1]}/${point.coordinates[0]}/` +
                 `${options.scenario.name}/indicator/${options.indicator.name}/`;
     return this.makeDataRequest(url, options);
@@ -115,6 +122,11 @@ export class IndicatorService {
       searchParams.append('percentile', percentileOpts.percentile.toString());
     }
 
+    if (this.hasDistanceParam(options.params)) {
+      const distanceParams = options.params as IndicatorDistanceQueryParams;
+      searchParams.append('distance', distanceParams.distance.toString());
+    }
+
     if (options.params.years) {
       searchParams.append('years', options.params.years.join(','));
     }
@@ -132,5 +144,9 @@ export class IndicatorService {
     }
 
     return searchParams;
+  }
+
+  private hasDistanceParam(params: IndicatorQueryParams): params is IndicatorDistanceQueryParams {
+    return (params as IndicatorDistanceQueryParams).distance !== undefined;
   }
 }


### PR DESCRIPTION
## Overview

Adds a distance parameter for all climate data requests. This is to allow querying the API for locations that are close to but not within an imported map cell.


### Demo

N/A


### Notes

 - I considered adding an optional parameter to `IndicatorQueryParams` and enforcing that it is only used for Lat/Lon queries via a validation method, which would have involved much fewer code changes, but after discussing the options with @ddohler I went with this approach instead, so that the type system ensures that only Lat/Lon queries supply a `distance` parameter.


## Testing Instructions

 * `yarn run build:library`
 * `npm pack`

## Checklist
- [x] `yarn run lint` clean?
- [x] `yarn run build:library` clean?
- [x] `npm pack` clean?
- [x] `CHANGELOG.md` updated?

Closes #47

